### PR TITLE
Fix critical issue for ko/strings.xml

### DIFF
--- a/languages/ko/strings.xml
+++ b/languages/ko/strings.xml
@@ -44,7 +44,7 @@
     <string name="donation_subs_manage_btn_text">정기 기부 중단</string>
 
     <string name="format_altitude">고도</string>
-    <string name="format_degrees">도</string>
+    <string name="format_degrees">좌표</string>
     <string name="format_gb">GB</string>
     <string name="format_hz">Hz</string>
     <string name="format_kbits">kbps</string>
@@ -176,8 +176,8 @@
     <string name="prefs_gps_accuracy_text">다음보다 큰 오차가 있는 GPS 데이터는 무시</string>
     <string name="prefs_gps_disabled_gps_and_google_text">GPS와 Google 위치 정확도가 비활성화된 경우 경고 표시</string>
     <string name="prefs_gps_disabled_gps_only_text">GPS가 비활성화된 경우에만 경고 표시</string>
-    <string name="prefs_gps_disabled_no_warning_text">경고 및 @string/rec_fix_text 버튼을 표시하지 않음</string>
-    <string name="prefs_gps_disabled_warning_text">GPS 비활성화 경고 및 @string/rec_fix_text 버튼 설정</string>
+    <string name="prefs_gps_disabled_no_warning_text">경고 및 수정 버튼을 표시하지 않음</string>
+    <string name="prefs_gps_disabled_warning_text">GPS 비활성화 경고 및 수정 버튼(Fix) 설정</string>
     <string name="prefs_info_more_category_text">정보 / 기타</string>
     <string name="prefs_kill_services_sum_text">기기가 자동 시작 및 백그라운드 동작 설정을 지원합니다. 비허용된 경우 여기를 탭하여 예외에 추가(자동 시작 허용 등)하고 앱이 백그라운드에서 실행될 수 있도록 하세요.</string>
     <string name="prefs_kill_services_text">백그라운드 작업 허용</string>
@@ -193,7 +193,7 @@
     <string name="prefs_orientation_landscape">가로</string>
     <string name="prefs_orientation_landscape_reversed">가로 반전</string>
     <string name="prefs_orientation_portrait">세로</string>
-    <string name="prefs_other_auto_deleting_sum_text">저장공간이 부족하면 가장 오래된 동영상을 삭제하며 녹화합니다.</string>
+    <string name="prefs_other_auto_deleting_sum_text">저장공간이 부족하면 가장 오래된 동영상을 삭제하며 녹화합니다</string> <!-- A period is automatically added to the end of this sentence -->
     <string name="prefs_other_auto_deleting_text">루프 녹화</string>
     <string name="prefs_other_keep_screen_on_text">화면 켜짐 유지</string>
     <string name="prefs_other_miles_sum_text">킬로미터 대신 마일을 사용하려면 설정하세요.</string>
@@ -207,7 +207,7 @@
     <string name="prefs_other_show_coordinates_text">좌표</string>
     <string name="prefs_other_show_speed_text">속도</string>
     <string name="prefs_other_show_ui_elements_text">화면에 표시할 항목</string>
-    <string name="prefs_other_video_duration_text">비디오 길이(저장 빈도)</string>
+    <string name="prefs_other_video_duration_text">동영상 길이(저장 빈도)</string>
     <string name="prefs_overlay_app_btn_text">앱 실행</string>
     <string name="prefs_overlay_buttons_text">플로팅 윈도우 버튼/요소 편집</string>
     <string name="prefs_overlay_close_btn_text">플로팅 윈도우 닫기</string>
@@ -278,7 +278,7 @@
     <string name="prefs_subtitles_update_address_frequency_text">주소 업데이트 속도</string>
     <string name="prefs_support_sum_text">버그 보고, 충돌 또는 제안</string>
     <string name="prefs_support_text">지원(피드백)</string>
-    <string name="prefs_system_alert_window_sum_text">이 앱이 다른 앱 위에 표시될 수 있도록 설정하세요. 이것은 자동으로 비디오 녹화를 시작/중지하거나 플로팅 윈도우를 표시하는 데 필요합니다.</string>
+    <string name="prefs_system_alert_window_sum_text">이 앱이 다른 앱 위에 표시될 수 있도록 설정하세요. 이것은 자동으로 동영상 녹화를 시작/중지하거나 플로팅 윈도우를 표시하는 데 필요합니다.</string>
     <string name="prefs_system_alert_window_text">다른 앱 위에 표시</string>
     <string name="prefs_tip_apply_auto_rec_on_text">이 설정을 적용하려면 첫 화면(녹화)으로 돌아가세요.</string>
     <string name="prefs_toolbar_title_setting">설정</string>
@@ -310,7 +310,7 @@
     <string name="prefs_video_focus_night_text">카메라 초점 (야간)</string>
     <string name="prefs_video_focus_text">카메라 초점 (주간)</string>
     <string name="prefs_video_fps_range_text">초당 프레임 (FPS)</string>
-    <string name="prefs_video_hevc_sum_text">HEVC (H.265) 포맷으로 녹화하면 공간을 절약할 수 있습니다. 하지만 다른 비디오 재생 장치 또는 프로그램에서 이 비디오를 재생하지 못할 수도 있습니다. 변경 후 해상도와 비트레이트를 재설정해야 합니다.</string>
+    <string name="prefs_video_hevc_sum_text">HEVC (H.265) 포맷으로 녹화하면 공간을 절약할 수 있습니다. 하지만 다른 비디오 재생 장치 또는 프로그램에서 이 동영상을 재생하지 못할 수도 있습니다. 변경 후 해상도와 비트레이트를 재설정해야 합니다.</string>
     <string name="prefs_video_hevc_text">고효율 비디오 코딩(HEVC)</string>
     <string name="prefs_video_orientation_text">동영상 및 휴대폰 방향</string>
     <string name="prefs_video_resolution_text">동영상 해상도</string>
@@ -321,7 +321,7 @@
     <string name="prefs_video_stabilization_text">떨림 보정</string>
     <string name="prefs_zoom_text">디지털 줌</string>
 
-    <string name="rec_day_night_btn_auto_text">Auto</string>
+    <string name="rec_day_night_btn_auto_text">자동</string>
     <string name="rec_fix_short_text">@string/rec_fix_text</string>
     <string name="rec_fix_text">Fix</string>
     <string name="rec_free_space_text">Free</string>
@@ -398,11 +398,11 @@
 
     <string name="msg_dialog_camera_battery_optimization_title">카메라에 액세스하는 동안 오류가 발생했습니다. 배터리 최적화 활성화됨</string>
     <string name="msg_dialog_camera_battery_optimization_subtitle">향후 카메라 오류를 방지하려면 기기 설정에서 이 앱의 배터리 최적화를 비활성화하세요.</string>
-	
-    <string name="prefs_rules_auto_start_only_with_service_text">서비스가 실행 중일 때만 자동 녹화</string>
-    <string name="prefs_rules_auto_start_only_with_service_sum_text">이 옵션을 활성화하면 모니터링 서비스가 실행되지 않고 알림 패널에 표시되지 않는 경우 자동 녹음이 수행되지 않습니다.</string>
 
-	
-    <string name="prefs_subtitles_position_bottom_text">하단에 자막</string>
-    <string name="prefs_subtitles_position_bottom_sum_text">비디오 하단에 오버레이 자막</string>
+    <string name="prefs_rules_auto_start_only_with_service_text">서비스가 실행 중일 때만 자동 녹화</string>
+    <string name="prefs_rules_auto_start_only_with_service_sum_text">이 옵션을 활성화하면 모니터링 서비스가 실행되지 않고 알림 패널에 표시되지 않는 경우 자동 녹화가 수행되지 않습니다.</string>
+
+
+    <string name="prefs_subtitles_position_bottom_text">하단 자막</string>
+    <string name="prefs_subtitles_position_bottom_sum_text">자막을 동영상 하단에 표시</string>
 </resources>


### PR DESCRIPTION
Emergency update for ko/strings.xml

The `@string/rec_fix_text` in the middle of the text was not replaced as I expected, so I corrected it urgently. And I misunderstood and translated the `format_degrees` tag.

I didn't know this would happen. I'm sorry.

And by looking at the newly reflected translation again, I made some additional small improvements.

Thank you for making this great app.